### PR TITLE
Add missing options

### DIFF
--- a/src/main/java/io/beautifier/core/Options.java
+++ b/src/main/java/io/beautifier/core/Options.java
@@ -197,7 +197,7 @@ public abstract class Options<SELF extends Options<SELF>> {
 		}
 
 		@SuppressWarnings("unchecked")
-		private SELF self() {
+		protected SELF self() {
 			return (SELF) this;
 		}
 

--- a/src/main/java/io/beautifier/css/CSSOptions.java
+++ b/src/main/java/io/beautifier/css/CSSOptions.java
@@ -105,6 +105,36 @@ public class CSSOptions extends io.beautifier.core.Options<CSSOptions> {
 			}
 		}
 
+		@Deprecated
+		public Builder selector_separator(String selector_separator) {
+			this.selector_separator = selector_separator;
+			return self();
+		}
+		
+		public Builder selector_separator_newline(Boolean selector_separator_newline) {
+			this.selector_separator_newline = selector_separator_newline;
+			return self();
+		}
+
+		public Builder newline_between_rules(Boolean newline_between_rules) {
+			this.newline_between_rules = newline_between_rules;
+			return self();
+		}
+
+		public Builder space_around_selector_separator(Boolean space_around_selector_separator) {
+			this.space_around_selector_separator = space_around_selector_separator;
+			return self();
+		}
+
+		public Builder space_around_combinator(Boolean space_around_combinator) {
+			this.space_around_combinator = space_around_combinator;
+			return self();
+		}
+
+		public Builder BraceStyle(BraceStyle brace_style) {
+			this.brace_style = brace_style;
+			return self();
+		}
 	}
 
 	public enum BraceStyle {

--- a/src/main/java/io/beautifier/html/HTMLOptions.java
+++ b/src/main/java/io/beautifier/html/HTMLOptions.java
@@ -146,6 +146,75 @@ public class HTMLOptions extends io.beautifier.core.Options<HTMLOptions> {
 			}
 		}
 
+		public Builder indent_inner_html(Boolean indent_inner_html) {
+			this.indent_inner_html = indent_inner_html;
+			return self();
+		}
+
+		public Builder indent_body_inner_html(Boolean indent_body_inner_html) {
+			this.indent_body_inner_html = indent_body_inner_html;
+			return self();
+		}
+
+		public Builder indent_head_inner_html(Boolean indent_head_inner_html) {
+			this.indent_head_inner_html = indent_head_inner_html;
+			return self();
+		}
+
+		public Builder indent_handlebars(Boolean indent_handlebars) {
+			this.indent_handlebars = indent_handlebars;
+			return self();
+		}
+
+		public Builder wrap_attributes(WrapAttributes wrap_attributes) {
+			this.wrap_attributes = wrap_attributes;
+			return self();
+		}
+
+		public Builder wrap_attributes_min_attrs(Integer wrap_attributes_min_attrs) {
+			this.wrap_attributes_min_attrs = wrap_attributes_min_attrs;
+			return self();
+		}
+
+		public Builder wrap_attributes_indent_size(Integer wrap_attributes_indent_size) {
+			this.wrap_attributes_indent_size = wrap_attributes_indent_size;
+			return self();
+		}
+
+		public Builder unformatted_content_delimiter(String unformatted_content_delimiter) {
+			this.unformatted_content_delimiter = unformatted_content_delimiter;
+			return self();
+		}
+
+		public Builder indent_scripts(IndentScripts indent_scripts) {
+			this.indent_scripts = indent_scripts;
+			return self();
+		}
+
+		public Builder extra_liners(Set<String> extra_liners) {
+			this.extra_liners = extra_liners;
+			return self();
+		}
+
+		public Builder inline(Set<String> inline) {
+			this.inline = inline;
+			return self();
+		}
+
+		public Builder void_elements(Set<String> void_elements) {
+			this.void_elements = void_elements;
+			return self();
+		}
+
+		public Builder unformatted(Set<String> unformatted) {
+			this.unformatted = unformatted;
+			return self();
+		}
+
+		public Builder content_unformatted(Set<String> content_unformatted) {
+			this.content_unformatted = content_unformatted;
+			return self();
+		}
 	}
 
 	public enum WrapAttributes {

--- a/src/main/java/io/beautifier/javascript/JavaScriptOptions.java
+++ b/src/main/java/io/beautifier/javascript/JavaScriptOptions.java
@@ -149,6 +149,85 @@ public class JavaScriptOptions extends io.beautifier.core.Options<JavaScriptOpti
 			}
 		}
 
+		public Builder brace_style(BraceStyle brace_style) {
+			this.brace_style = brace_style;
+			return self();
+		}
+
+		public Builder brace_preserve_inline(Boolean brace_preserve_inline) {
+			this.brace_preserve_inline = brace_preserve_inline;
+			return self();
+		}
+
+		public Builder unindent_chained_methods(Boolean unindent_chained_methods) {
+			this.unindent_chained_methods = unindent_chained_methods;
+			return self();
+		}
+
+		public Builder break_chained_methods(Boolean break_chained_methods) {
+			this.break_chained_methods = break_chained_methods;
+			return self();
+		}
+
+		public Builder space_in_paren(Boolean space_in_paren) {
+			this.space_in_paren = space_in_paren;
+			return self();
+		}
+
+		public Builder space_in_empty_paren(Boolean space_in_empty_paren) {
+			this.space_in_empty_paren = space_in_empty_paren;
+			return self();
+		}
+
+		public Builder jslint_happy(Boolean jslint_happy) {
+			this.jslint_happy = jslint_happy;
+			return self();
+		}
+
+		public Builder space_after_anon_function(Boolean space_after_anon_function) {
+			this.space_after_anon_function = space_after_anon_function;
+			return self();
+		}
+
+		public Builder space_after_named_function(Boolean space_after_named_function) {
+			this.space_after_named_function = space_after_named_function;
+			return self();
+		}
+
+		public Builder keep_array_indentation(Boolean keep_array_indentation) {
+			this.keep_array_indentation = keep_array_indentation;
+			return self();
+		}
+
+		public Builder space_before_conditional(Boolean space_before_conditional) {
+			this.space_before_conditional = space_before_conditional;
+			return self();
+		}
+
+		public Builder unescape_strings(Boolean unescape_strings) {
+			this.unescape_strings = unescape_strings;
+			return self();
+		}
+
+		public Builder e4x(Boolean e4x) {
+			this.e4x = e4x;
+			return self();
+		}
+
+		public Builder comma_first(Boolean comma_first) {
+			this.comma_first = comma_first;
+			return self();
+		}
+
+		public Builder operator_position(OperatorPosition operator_position) {
+			this.operator_position = operator_position;
+			return self();
+		}
+
+		public Builder test_output_raw(Boolean test_output_raw) {
+			this.test_output_raw = test_output_raw;
+			return self();
+		}
 	}
 
 	/**


### PR DESCRIPTION
I have the feeling something is wrong with the Builder options in the child classes of `io.beautifier.core.Options.Builder`

Without this change the I had a compile error on this line:
https://github.com/beautifier/js-beautify-java/blob/99fb12c70494a85095113b92d2ecb71fdab92001/src/test/java/io/beautifier/css/OptionsTests.java#L18

> ERROR: The method newline_between_rules(boolean) is undefined for the type CSSOptions.Builder

I have no idea if those lines are supposed to be generated or not.